### PR TITLE
Refactor trying to sleep into an activity

### DIFF
--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -403,5 +403,13 @@
     "type": "activity_type",
     "stop_phrase": "Stop cutting your hair?",
     "based_on": "speed"
+  },
+  {
+    "id": "ACT_TRY_SLEEP",
+    "type": "activity_type",
+    "stop_phrase": "Stop trying to fall asleep?",
+    "rooted": true,
+    "based_on": "speed",
+    "suspendable" : false
   }
 ]

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -88,7 +88,8 @@ activity_handlers::do_turn_functions = {
     { activity_id( "ACT_DIG" ), dig_do_turn },
     { activity_id( "ACT_FILL_PIT" ), fill_pit_do_turn },
     { activity_id( "ACT_TILL_PLOT" ), till_plot_do_turn },
-    { activity_id( "ACT_PLANT_PLOT" ), plant_plot_do_turn }
+    { activity_id( "ACT_PLANT_PLOT" ), plant_plot_do_turn },
+    { activity_id( "ACT_TRY_SLEEP" ), try_sleep_do_turn }
 };
 
 const std::map< activity_id, std::function<void( player_activity *, player * )> >
@@ -125,6 +126,7 @@ activity_handlers::finish_functions = {
     { activity_id( "ACT_WAIT" ), wait_finish },
     { activity_id( "ACT_WAIT_WEATHER" ), wait_weather_finish },
     { activity_id( "ACT_WAIT_NPC" ), wait_npc_finish },
+    { activity_id( "ACT_TRY_SLEEP" ), try_sleep_finish },
     { activity_id( "ACT_CRAFT" ), craft_finish },
     { activity_id( "ACT_LONGCRAFT" ), longcraft_finish },
     { activity_id( "ACT_DISASSEMBLE" ), disassemble_finish },
@@ -2619,6 +2621,29 @@ void activity_handlers::wait_weather_finish( player_activity *act, player *p )
 void activity_handlers::wait_npc_finish( player_activity *act, player *p )
 {
     p->add_msg_if_player( _( "%s finishes with you..." ), act->str_values[0].c_str() );
+    act->set_to_null();
+}
+
+void activity_handlers::try_sleep_do_turn( player_activity *act, player *p )
+{
+    if( p->can_sleep() ) {
+        act->set_to_null();
+        p->fall_asleep();
+    } else {
+        const int i = rng( 0, 1000 );
+        if( !i ) {
+            p->add_msg_if_player( _( "You toss and turn..." ) );
+        }
+    }
+}
+
+void activity_handlers::try_sleep_finish( player_activity *act, player *p )
+{
+    if( p->can_sleep() ) {
+        p->fall_asleep();
+    } else {
+        p->add_msg_if_player( _( "You try to sleep, but can't..." ) );
+    }
     act->set_to_null();
 }
 

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -60,6 +60,7 @@ void dig_do_turn( player_activity *act, player *p );
 void fill_pit_do_turn( player_activity *act, player *p );
 void till_plot_do_turn( player_activity *act, player *p );
 void plant_plot_do_turn( player_activity *act, player *p );
+void try_sleep_do_turn( player_activity *act, player *p );
 
 // defined in activity_handlers.cpp
 extern const std::map< activity_id, std::function<void( player_activity *, player * )> >
@@ -94,6 +95,7 @@ void read_finish( player_activity *act, player *p );
 void wait_finish( player_activity *act, player *p );
 void wait_weather_finish( player_activity *act, player *p );
 void wait_npc_finish( player_activity *act, player *p );
+void try_sleep_finish( player_activity *act, player *p );
 void craft_finish( player_activity *act, player *p );
 void longcraft_finish( player_activity *act, player *p );
 void disassemble_finish( player_activity *act, player *p );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -769,8 +769,41 @@ static void sleep()
         u.add_effect( effect_alarm_clock, 1_hours * as_m.ret );
     }
 
+    // Reuse menu again
+    as_m.reset();
+    as_m.text = _( "How long to try to sleep?" );
+
+    if( !u.has_watch() ) {
+        as_m.entries.emplace_back( uimenu_entry( 1, true, '1', _( "Wait 1800 heartbeats" ) ) );
+        as_m.entries.emplace_back( uimenu_entry( 2, true, '2', _( "Wait 3600 heartbeats" ) ) );
+        as_m.entries.emplace_back( uimenu_entry( 4, true, '$', _( "Until you fall asleep" ) ) );
+    } else {
+        as_m.entries.emplace_back( uimenu_entry( 1, true, '1', _( "30 minutes" ) ) );
+        as_m.entries.emplace_back( uimenu_entry( 2, true, '2', _( "1 hours" ) ) );
+        as_m.entries.emplace_back( uimenu_entry( 3, true, '3', _( "2 hours" ) ) );
+        as_m.entries.emplace_back( uimenu_entry( 4, true, '$', _( "Until you fall asleep" ) ) );
+    }
+    as_m.query();
+
+    int dur;
+    switch( as_m.ret ) {
+        case 1:
+            dur = to_moves<int>( 30_minutes );
+            break;
+        case 2:
+            dur = to_moves<int>( 1_hours );
+            break;
+        case 3:
+            dur = to_moves<int>( 2_hours );
+            break;
+        case 4:
+            // So we're not *actually* going to wait to until fall asleep,
+            // we'll wait for some unreasonable amount of time before giving up
+            dur = to_moves<int>( 24_hours );
+    }
+
     u.moves = 0;
-    u.try_to_sleep();
+    u.try_to_sleep( dur );
 }
 
 static void loot()

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -9845,10 +9845,24 @@ bool player::can_sleep()
         // Sleep ain't happening until that meth wears off completely.
         return false;
     }
-    int sleepy = sleep_spot( pos() );
-    sleepy += rng( -8, 8 );
-    if( sleepy > 0 ) {
-        return true;
+
+    // Since there's a bit of randomness to falling asleep, we want to
+    // prevent exploiting this if can_sleep() gets called over and over.
+    // Only actually check if we can fall asleep no more frequently than
+    // every 30 minutes.  We're assuming that if we return true, we'll
+    // immediately be falling asleep after that.
+    //
+    // Also if player debug menu'd time backwards this breaks, just do the
+    // check anyway, this will reset the timer if 'dur' is negative.
+    const time_point now = calendar::turn;
+    const time_duration dur = now - last_sleep_check;
+    if( dur >= 30_minutes || dur < 0_turns ) {
+        last_sleep_check = now;
+        int sleepy = sleep_spot( pos() );
+        sleepy += rng( -8, 8 );
+        if( sleepy > 0 ) {
+            return true;
+        }
     }
     return false;
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -9613,6 +9613,11 @@ const recipe_subset player::get_available_recipes( const inventory &crafting_inv
 
 void player::try_to_sleep()
 {
+    try_to_sleep( to_moves<int>( 30_minutes ) );
+}
+
+void player::try_to_sleep( const int movs )
+{
     const optional_vpart_position vp = g->m.veh_at( pos() );
     const trap &trap_at_pos = g->m.tr_at(pos());
     const ter_id ter_at_pos = g->m.ter(pos());
@@ -9691,7 +9696,8 @@ void player::try_to_sleep()
                  _("It's hard to get to sleep on this %s."),
                  ter_at_pos.obj().name().c_str() );
     }
-    add_effect( effect_lying_down, 30_minutes );
+
+    assign_activity( activity_id( "ACT_TRY_SLEEP" ), movs );
 }
 
 int player::sleep_spot( const tripoint &p ) const

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -9847,6 +9847,37 @@ bool player::can_sleep()
     return false;
 }
 
+void player::fall_asleep()
+{
+    add_msg_if_player( _( "You fall asleep." ) );
+    // Communicate to the player that he is using items on the floor
+    std::string item_name = is_snuggling();
+    if( item_name == "many" ) {
+        if( one_in( 15 ) ) {
+            add_msg_if_player( _( "You nestle your pile of clothes for warmth." ) );
+        } else {
+            add_msg_if_player( _( "You use your pile of clothes for warmth." ) );
+        }
+    } else if( item_name != "nothing" ) {
+        if( one_in( 15 ) ) {
+            add_msg_if_player( _( "You snuggle your %s to keep warm." ), item_name.c_str() );
+        } else {
+            add_msg_if_player( _( "You use your %s to keep warm." ), item_name.c_str() );
+        }
+    }
+    if( has_active_mutation( trait_id( "HIBERNATE" ) ) && get_hunger() < -60 ) {
+        add_memorial_log( pgettext( "memorial_male", "Entered hibernation." ),
+                          pgettext( "memorial_female", "Entered hibernation." ) );
+        // some days worth of round-the-clock Snooze.  Cata seasons default to 14 days.
+        fall_asleep( 10_days );
+        // If you're not fatigued enough for 10 days, you won't sleep the whole thing.
+        // In practice, the fatigue from filling the tank from (no msg) to Time For Bed
+        // will last about 8 days.
+    }
+
+    fall_asleep( 10_hours ); // default max sleep time.
+}
+
 void player::fall_asleep( const time_duration &duration )
 {
     if( activity ) {

--- a/src/player.h
+++ b/src/player.h
@@ -1064,6 +1064,7 @@ class player : public Character
         /** Checked each turn during "lying_down", returns true if the player falls asleep */
         bool can_sleep();
         /** Adds "sleep" to the player */
+        void fall_asleep();
         void fall_asleep( const time_duration &duration );
         /** Removes "sleep" and "lying_down" from the player */
         void wake_up();

--- a/src/player.h
+++ b/src/player.h
@@ -1064,6 +1064,7 @@ class player : public Character
         int sleep_spot( const tripoint &p ) const;
         /** Checked each turn during "lying_down", returns true if the player falls asleep */
         bool can_sleep();
+
         /** Adds "sleep" to the player */
         void fall_asleep();
         void fall_asleep( const time_duration &duration );
@@ -1071,6 +1072,12 @@ class player : public Character
         void wake_up();
         /** Checks to see if the player is using floor items to keep warm, and return the name of one such item if so */
         std::string is_snuggling() const;
+
+    private:
+        /** last time we checked for sleep */
+        time_point last_sleep_check = calendar::time_of_cataclysm;
+
+    public:
         /** Returns a value from 1.0 to 5.0 that acts as a multiplier
          * for the time taken to perform tasks that require detail vision,
          * above 4.0 means these activities cannot be performed. */

--- a/src/player.h
+++ b/src/player.h
@@ -1057,8 +1057,9 @@ class player : public Character
         void do_read( item &book );
         /** Note that we've read a book at least once. **/
         bool has_identified( const std::string &item_id ) const;
-        /** Handles sleep attempts by the player, adds "lying_down" */
+        /** Handles sleep attempts by the player, starts ACT_TRY_SLEEP activity */
         void try_to_sleep();
+        void try_to_sleep( const int movs );
         /** Rate point's ability to serve as a bed. Takes mutations, fatigue and stimulants into account. */
         int sleep_spot( const tripoint &p ) const;
         /** Checked each turn during "lying_down", returns true if the player falls asleep */

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -990,33 +990,7 @@ void player::hardcoded_effects( effect &it )
     } else if( id == effect_lying_down ) {
         set_moves( 0 );
         if( can_sleep() ) {
-            add_msg_if_player( _( "You fall asleep." ) );
-            // Communicate to the player that he is using items on the floor
-            std::string item_name = is_snuggling();
-            if( item_name == "many" ) {
-                if( one_in( 15 ) ) {
-                    add_msg_if_player( _( "You nestle your pile of clothes for warmth." ) );
-                } else {
-                    add_msg_if_player( _( "You use your pile of clothes for warmth." ) );
-                }
-            } else if( item_name != "nothing" ) {
-                if( one_in( 15 ) ) {
-                    add_msg_if_player( _( "You snuggle your %s to keep warm." ), item_name.c_str() );
-                } else {
-                    add_msg_if_player( _( "You use your %s to keep warm." ), item_name.c_str() );
-                }
-            }
-            if( has_active_mutation( trait_id( "HIBERNATE" ) ) && get_hunger() < -60 ) {
-                add_memorial_log( pgettext( "memorial_male", "Entered hibernation." ),
-                                  pgettext( "memorial_female", "Entered hibernation." ) );
-                // some days worth of round-the-clock Snooze.  Cata seasons default to 14 days.
-                fall_asleep( 10_days );
-                // If you're not fatigued enough for 10 days, you won't sleep the whole thing.
-                // In practice, the fatigue from filling the tank from (no msg) to Time For Bed
-                // will last about 8 days.
-            }
-
-            fall_asleep( 10_hours ); // default max sleep time.
+            fall_asleep();
             // Set ourselves up for removal
             it.set_duration( 0 );
         }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -454,6 +454,7 @@ void player::load( JsonObject &data )
     data.read( "cash", cash );
     data.read( "recoil", recoil );
     data.read( "in_vehicle", in_vehicle );
+    data.read( "last_sleep_check", last_sleep_check );
     if( data.read( "id", tmpid ) ) {
         setID( tmpid );
     }
@@ -533,6 +534,7 @@ void player::store( JsonOut &json ) const
 
     // energy
     json.member( "stim", stim );
+    json.member( "last_sleep_check", last_sleep_check );
     // pain
     json.member( "pkill", pkill );
     // misc levels


### PR DESCRIPTION
#### Summary
```SUMMARY: Bugfixes "Make trying to sleep into an activity"```

#### Purpose of change
The way trying to sleep currently works is you just pass out for 30 minutes and then we check if you're actually asleep.

This changes it so a) you choose how long to try to fall asleep b) instead of skipping ahead 30 minutes, we try each turn to fall asleep until the limit chosen.

This saves key-presses by giving the player the option of how long to try to sleep instead of making the player repeatedly try.

- Can be interrupted manually with `.` or by creatures wandering around nearby
- New menu with 30 minutes/1 hours/2 hours/Until you fall asleep ( 24 hours ) to choose how long to try to fall asleep (note there's heartbeats instead if you don't have a watch)

#### Describe the solution
Refactor trying to fall asleep into a player activity instead of a "lying down effect".  Add a menu to decide how long to sleep.

